### PR TITLE
Fix php74 implode

### DIFF
--- a/classes/stack/bulktester.class.php
+++ b/classes/stack/bulktester.class.php
@@ -120,8 +120,7 @@ class stack_bulk_tester
 
                 if ($questionproblems !== array()) {
                     echo $OUTPUT->heading($questionnamelink, 4);
-                    echo html_writer::tag('ul', implode($questionproblems, "\n"));
-
+                    echo html_writer::tag('ul', implode("\n", $questionproblems));
                 }
 
                 $previewurl = new moodle_url($questiontestsurl, array('questionid' => $questionid));

--- a/classes/stack/cas/casstring.class.php
+++ b/classes/stack/cas/casstring.class.php
@@ -1106,7 +1106,7 @@ class stack_cas_casstring
 
         if (!$valid) {
             $this->valid = false;
-            $a = implode($found, ', ');
+            $a = implode(', ', $found);
             $this->add_error(stack_string('stackCas_underscores', $a));
         }
     }

--- a/classes/stack/cas/casstring.units.class.php
+++ b/classes/stack/cas/casstring.units.class.php
@@ -178,9 +178,9 @@ class stack_cas_casstring_units
             $multiplier[] = $unit[1];
             $tex[] = self::maximalocal_units_tex($unit[2]);
         }
-        $maximalocal .= '    stack_unit_si_prefix_code:[' . implode($code, ', ') . "],\n";
-        $maximalocal .= '    stack_unit_si_prefix_multiplier:[' . implode($multiplier, ', ') . "],\n";
-        $maximalocal .= '    stack_unit_si_prefix_tex:[' . implode($tex, ', ') . "],\n";
+        $maximalocal .= '    stack_unit_si_prefix_code:[' . implode(', ', $code) . "],\n";
+        $maximalocal .= '    stack_unit_si_prefix_multiplier:[' . implode(', ', $multiplier) . "],\n";
+        $maximalocal .= '    stack_unit_si_prefix_tex:[' . implode(', ', $tex,) . "],\n";
 
         $code = array();
         $conversions = array();
@@ -191,9 +191,9 @@ class stack_cas_casstring_units
             $tex[] = self::maximalocal_units_tex($unit[2]);
         }
 
-        $maximalocal .= '    stack_unit_si_unit_code:[' . implode($code, ', ') . "],\n";
-        $maximalocal .= '    stack_unit_si_unit_conversions:[' . implode($conversions, ', ') . "],\n";
-        $maximalocal .= '    stack_unit_si_unit_tex:[' . implode($tex, ', ') . "],\n";
+        $maximalocal .= '    stack_unit_si_unit_code:[' . implode(', ', $code) . "],\n";
+        $maximalocal .= '    stack_unit_si_unit_conversions:[' . implode(', ', $conversions) . "],\n";
+        $maximalocal .= '    stack_unit_si_unit_tex:[' . implode(', ', $tex) . "],\n";
 
         $code = array();
         $conversions = array();
@@ -204,9 +204,9 @@ class stack_cas_casstring_units
             $tex[] = self::maximalocal_units_tex($unit[2]);
         }
 
-        $maximalocal .= '    stack_unit_other_unit_code:[' . implode($code, ', ') . "],\n";
-        $maximalocal .= '    stack_unit_other_unit_conversions:[' . implode($conversions, ', ') . "],\n";
-        $maximalocal .= '    stack_unit_other_unit_tex:[' . implode($tex, ', ') . "],\n";
+        $maximalocal .= '    stack_unit_other_unit_code:[' . implode(', ', $code) . "],\n";
+        $maximalocal .= '    stack_unit_other_unit_conversions:[' . implode(', ', $conversions) . "],\n";
+        $maximalocal .= '    stack_unit_other_unit_tex:[' . implode(', ', $tex) . "],\n";
 
         return $maximalocal;
     }
@@ -338,6 +338,6 @@ class stack_cas_casstring_units
 
         return (stack_string('stackCas_unknownUnitsCase',
             array('forbid' => stack_maxima_format_casstring($key),
-                'unit' => stack_maxima_format_casstring('[' . implode($invalid[strtolower($key)], ", ") . ']'))));
+                'unit' => stack_maxima_format_casstring('[' . implode(", ", $invalid[strtolower($key)]) . ']'))));
     }
 }


### PR DESCRIPTION
This PR fixes calls of implode() where the arguments where swapped ().
Beginning with 7.4 the undocumented use of the form  implode(pieces, glue) it is no longer accepted.

see mantis: https://mantis.ilias.de/view.php?id=29016