### PR TITLE
Limiting xqcas_test_parameters logging to accuracy of milliseconds

### DIFF
--- a/classes/class.assStackQuestion.php
+++ b/classes/class.assStackQuestion.php
@@ -197,11 +197,13 @@ class assStackQuestion extends assQuestion implements iQuestionCondition
 		$question_evaluation = $evaluation_object->evaluateQuestion();
 		$question_evaluation->calculatePoints();
 		/*FAU-SCRIPT*/
+		// current time in accuracy of milliseconds
+		$now = substr(microtime(true) * 1000, 0, 13);
 		$db->insert("xqcas_test_parameters", array(
 			"active_id" => array("integer", $active_id),
 			"pass" => array("integer", $pass),
 			"question_id" => array("integer", $this->getId()),
-			"tstamp" => array("integer", microtime()),
+			"tstamp" => array("integer", $now),
 			"value" => array("clob", "#E# " . $question_evaluation->getQuestionNoteInstantiated())
 		));
 		/*FAU-SCRIPT*/

--- a/classes/class.assStackQuestionGUI.php
+++ b/classes/class.assStackQuestionGUI.php
@@ -574,12 +574,13 @@ class assStackQuestionGUI extends assQuestionGUI
 		$active_id = $_GET['active_id'];
 		include_once "./Modules/Test/classes/class.ilObjTest.php";
 		$pass = ilObjTest::_getPass($active_id);
-
+		// current time in accuracy of milliseconds
+		$now = substr(microtime(true) * 1000, 0, 13);
 		$db->insert("xqcas_test_parameters", array(
 			"active_id" => array("integer", $active_id),
 			"pass" => array("integer", $pass),
 			"question_id" => array("integer", $this->object->getId()),
-			"tstamp" => array("integer", microtime()),
+			"tstamp" => array("integer", $now),
 			"value" => array("clob", "#S# " . $this->object->getStackQuestion()->getQuestionNoteInstantiated())
 		));
 		/*FAU-SCRIPT*/

--- a/plugin.php
+++ b/plugin.php
@@ -9,7 +9,7 @@ $id = "xqcas";
  
 // code version; must be changed for all code changes
 
-$version = "3.1.13";
+$version = "3.1.14";
  
 // ilias min and max version; must always reflect the versions that should
 // run with the plugin


### PR DESCRIPTION
Limiting xqcas_test_parameters logging to accuracy of milliseconds (13 digits). Fixing "microtime(bool $as_float = false) : string|float" issue returning string with whitespace and floating point number.