### PR TITLE
Fix import error in locallib.php

### DIFF
--- a/classes/utils/locallib.php
+++ b/classes/utils/locallib.php
@@ -20,7 +20,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Stack.  If not, see <http://www.gnu.org/licenses/>.
 
-
+require_once(__DIR__ . '/../stack/mathsoutput/mathsoutput.class.php');
 include_once('./Customizing/global/plugins/Modules/TestQuestionPool/Questions/assStackQuestion/exceptions/class.assStackQuestionException.php');
 
 /**


### PR DESCRIPTION
When adding a STACK question to a test, an error occurs because the class "stack_maths" can't be found.
This commit fixes this issue.